### PR TITLE
The conditional compilation based on the lib's version wasn't working. (old patch)

### DIFF
--- a/swig/device.swg
+++ b/swig/device.swg
@@ -17,6 +17,7 @@
 /* See <cdio/device.h> for more extensive documentation. */
 
 %include "device_const.swg"
+#include <cdio/version.h>
 
 /* Set up to allow functions to return device lists of type "char
    *". We'll use a typedef so we can make sure to isolate this. I

--- a/swig/perliso9660.swg
+++ b/swig/perliso9660.swg
@@ -43,7 +43,7 @@ typedef uint8_t iso_extension_mask_t;
 %constant long int RECORD               = ISO_RECORD;
 
 /* When version 0.77 comes out, require it and fix this fix this. */
-#if 0
+#if LIBCDIO_VERSION_NUM >= 77
 %constant long int PROTECTION           = ISO_PROTECTION;
 #else
 %constant long int PROTECTION           = 16;


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Device-Cdio.
We thought you might be interested in it too.

    Description: The conditional compilation based on the lib's version wasn't working.
    Author: MartÃ­n Ferrari <martin.ferrari@gmail.com>
    Last-Update: 2017-10-30
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libdevice-cdio-perl.git/plain/debian/patches/03_version_information_in_swig.patch


This patch goes back to 2007; sorry for never forwarding it.
Probably the conditional could be changed/Dropped, as a newer version of
libcdio is required anyway.


Thanks for considering,
  gregor herrmann,
  Debian Perl Group
